### PR TITLE
[Changed] The github action base that this workflow uses

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -10,6 +10,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: pchalupa/site-health-check@v1
+      - uses: jtalk/url-health-check-action@v1.5
         with:
+          # Check the following URLs one by one sequentially.
           url: 'https://descartes-asdf.herokuapp.com/health'
+          max-attempts: 3 # Fail this action after 3 failed attempts.
+          retry-delay: 5s # Delay between retries.
+          retry-all: no # Retry all errors, including 404.


### PR DESCRIPTION
The previous one had no starts. [This one](https://github.com/marketplace/actions/url-health-check) seems to be more complete and reliable.